### PR TITLE
Tighten up html/dynamic-tag

### DIFF
--- a/html/dynamic-tag.ts
+++ b/html/dynamic-tag.ts
@@ -2,7 +2,22 @@ import { Renderer } from "../common/types";
 import { write } from "./writer";
 import { attrs } from "./attrs";
 
-const selfClosing = /^(?:polylin|ellips|sourc|(?:ba|u)s)e|p(?:olygon|a(?:ram|th))|c(?:o(?:mmand|l)|ircle)|keygen|track|input|embed|meta|area|stop|rect|lin[ek]|img|(?:wb|h)r|br$/;
+const voidElements = new Set([
+  'area',
+  'base',
+  'br',
+  'col',
+  'embed',
+  'hr',
+  'img',
+  'input',
+  'link',
+  'meta',
+  'param',
+  'source',
+  'track',
+  'wbr'
+]);
 interface RenderBodyObject {
   [x: string]: unknown;
   renderBody: Renderer;
@@ -13,7 +28,7 @@ export function dynamicTag(
   input: Record<string, unknown>,
   renderBody: (() => void) | undefined
 ) {
-  if (tag == null || tag === false) {
+  if (!tag) {
     if (renderBody) {
       renderBody();
     }
@@ -24,10 +39,10 @@ export function dynamicTag(
   if (typeof tag === "string") {
     write(`<${tag}${attrs(input)}>`);
 
-    if (selfClosing.test(tag)) {
+    if (voidElements.has(tag)) {
       if (renderBody) {
         throw new Error(
-          `A renderBody was provided for a self closing "${tag}" tag.`
+          `A renderBody was provided for a "${tag}" tag, which cannot have children.`
         );
       }
     } else {


### PR DESCRIPTION
## Description

- Renamed “self-closing tags” to “void elements” to be a little more technically correct

- Removed SVG elements from void elements, as all SVG elements can have children (`<title>`, `<desc>`, `<animate>`, etc.)

- Removed deprecated void elements (`<keygen>` and `<command>`)

- Not quite related but I couldn’t bring myself to make a PR about solely this: simplified the check for naked `renderBody`, since all of the falsy values in JS are unsuitable as tag names:
  + `false`, `undefined`, and `null` were already being caught
  + The empty string is obviously a bad idea (`<></>`)
  + Tag names can’t start with digits, so `0` and `0n` are out
  + `NaN` is the only stringified falsy value that _could_ conceivably be a tag name for XML somwhere, but I think we’d rather surface something that looks this much like an error as an error.

## Motivation and Context

Closes #3.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
