### PR TITLE
Micro-optimize SSR escape sequences

### DIFF
--- a/html/content.ts
+++ b/html/content.ts
@@ -3,7 +3,7 @@ const xmlAttrReg = /["\n]/g;
 const xmlReplacements = {
   "<": "&lt;",
   "&": "&amp;",
-  '"': "&quot;", // We only need double quotes since the runtime will only output double quotes.
+  '"': "&#34;", // We only need double quotes since the runtime will only output double quotes.
   "\n": "&#10;" // Preserve new lines so that they don't get normalized as space.
 } as const;
 
@@ -22,7 +22,7 @@ function replaceXMLChar(match: string) {
 
 function escapeTagEnding(tagName: string) {
   const closingTag = `</${tagName}`;
-  const replacement = `\\003c/${tagName}`;
+  const replacement = `<\\/${tagName}`;
   return escapeIfNeeded(val => val.replace(closingTag, replacement));
 }
 


### PR DESCRIPTION
## Description

Just two tiny improvements that jumped out at me.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

![Firefox View-Source shows that <\/script> and <\/style> are valid escape sequences for those end tags.](https://user-images.githubusercontent.com/8072522/67909139-9066ed80-fb54-11e9-9ff5-6d2bfc8e156b.png)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
